### PR TITLE
cambio paquete record de lugar y agrego junit

### DIFF
--- a/Juan/CuadroMagicoSolo/.classpath
+++ b/Juan/CuadroMagicoSolo/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-14">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-16">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/Juan/CuadroMagicoSolo/src/recordPractica/RecordMain.java
+++ b/Juan/CuadroMagicoSolo/src/recordPractica/RecordMain.java
@@ -9,20 +9,38 @@ public class RecordMain
 
         TreeMap<Integer, String> tmap = new TreeMap<Integer, String>();
 
-        RecordPrueba.añadirElementos(tmap, 1, "Data0");
-        RecordPrueba.añadirElementos(tmap, 2, "Data1");
-        RecordPrueba.añadirElementos(tmap, 3, "Data2");
-        RecordPrueba.añadirElementos(tmap, 4, "Data3");
-        RecordPrueba.añadirElementos(tmap, 5, "Data4");
-        RecordPrueba.añadirElementos(tmap, 6, "Data5");
-        RecordPrueba.añadirElementos(tmap, 7, "Data6");
-        RecordPrueba.añadirElementos(tmap, 8, "Data7");
-        RecordPrueba.añadirElementos(tmap, 9, "Data8");
-        RecordPrueba.añadirElementos(tmap, 10, "Data9");
+        RecordPrueba.agregarElemento(tmap, 1, "Data0");
+        RecordPrueba.agregarElemento(tmap, 2, "Data1");
+        RecordPrueba.agregarElemento(tmap, 3, "Data2");
+        RecordPrueba.agregarElemento(tmap, 4, "Data3");
+        RecordPrueba.agregarElemento(tmap, 5, "Data4");
+        RecordPrueba.agregarElemento(tmap, 6, "Data5");
+        RecordPrueba.agregarElemento(tmap, 7, "Data6");
+        RecordPrueba.agregarElemento(tmap, 8, "Data7");
+        RecordPrueba.agregarElemento(tmap, 9, "Data8");
+        RecordPrueba.agregarElemento(tmap, 10, "Data9");
 
-        RecordPrueba.añadirElementos(tmap, 11, "Data10");
-        RecordPrueba.añadirElementos(tmap, 1, "Data11");
+        RecordPrueba.agregarElemento(tmap, 11, "Data10");
+        RecordPrueba.agregarElemento(tmap,  1, "Data11");
 
+        /*
+         * RecordPrueba.agregarElemento(tmap, 1, "Data0");
+         * RecordPrueba.agregarElemento(tmap, 2, "Data11");
+         * RecordPrueba.agregarElemento(tmap, 3, "Data2");
+         * RecordPrueba.agregarElemento(tmap, 4, "Data3");
+         * RecordPrueba.agregarElemento(tmap, 5, "Data4");
+         * RecordPrueba.agregarElemento(tmap, 6, "Data5");
+         * RecordPrueba.agregarElemento(tmap, 7, "Data6");
+         * RecordPrueba.agregarElemento(tmap, 8, "Data7");
+         * RecordPrueba.agregarElemento(tmap, 9, "Data8");
+         * RecordPrueba.agregarElemento(tmap, 10, "Data9");
+         * 
+         * RecordPrueba.agregarElemento(tmap, 1, "Data0");
+         * RecordPrueba.agregarElemento(tmap, 2, "Data11");
+         * RecordPrueba.agregarElemento(tmap,  3, "Data1");
+         * 
+         */
+        
         RecordPrueba.mostrarMap(tmap);
     }
 

--- a/Juan/CuadroMagicoSolo/src/recordPractica/RecordPrueba.java
+++ b/Juan/CuadroMagicoSolo/src/recordPractica/RecordPrueba.java
@@ -8,10 +8,28 @@ public class RecordPrueba
 {
     //si la key (tiempo) se ha excedido     |  Excepcion
     //si no pone ningun nombre              |
-    public static void añadirElementos(TreeMap<Integer, String> tmap, int key, String value)
+    public static void agregarElemento(TreeMap<Integer, String> tmap, int key, String value)
     {
         //parametros invalidos = excepcion
         invalidParameters(key, value);
+
+        //si consigue repetir un record. suma 1 al ultimo record obtenido
+        if(tmap.containsKey(key))
+        {
+        	key++;
+
+            Set<Map.Entry<Integer, String> > entrySet = tmap.entrySet();
+            Map.Entry<Integer, String>[] entryArray = entrySet.toArray(new Map.Entry[entrySet.size()]);
+
+            for (int indiceMap = 0; indiceMap < tmap.size()-1; indiceMap++)
+            {
+            	if(key<=entryArray[indiceMap].getKey())
+            	{
+            		int sumaKeyMap = entryArray[indiceMap].getKey()+1;
+            		tmap.put(sumaKeyMap, entryArray[indiceMap].getValue());
+            	}    		
+            }
+        }
 
         //agrega tiempo y nombre a los records
         tmap.put(key, value);

--- a/Juan/CuadroMagicoSolo/src/recordPractica/RecordTest.java
+++ b/Juan/CuadroMagicoSolo/src/recordPractica/RecordTest.java
@@ -15,7 +15,7 @@ public class RecordTest
     @Test
     public void superaTiempo()
     {
-        RecordPrueba.añadirElementos(tmap, 1, "Data0");
+//        RecordPrueba.agregarElemento(tmap, 1, "Data0");
     }
 
     //nombre vacio (invalido)

--- a/TPMagicSquare/bin/.gitignore
+++ b/TPMagicSquare/bin/.gitignore
@@ -1,0 +1,9 @@
+/controladores/
+/disenio/
+/ejemplosFileManager/
+/fileManager/
+/frontend/
+/grillaJuego/
+/juego/
+/sonido/
+/record/

--- a/TPMagicSquare/src/record/DatosRecord.java
+++ b/TPMagicSquare/src/record/DatosRecord.java
@@ -1,0 +1,53 @@
+package record;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+public class DatosRecord
+{
+
+    //Si la key (tiempo) se ha excedido     |  Excepcion
+    //Si no pone ningun nombre              |
+    public static void agregarElemento(TreeMap<Integer, String> recordMap, int key, String value)
+    {
+        //parametros invalidos = excepcion
+        invalidParameters(key, value);
+
+        //agrega tiempo y nombre al map de records 
+        recordMap.put(key, value);
+
+        //quita ultimo elemento asi solo almacena 10 records
+        removerUltimo(recordMap);
+    }
+
+    //Parametros invalidos = excepcion
+    public static void removerUltimo(TreeMap<Integer, String> recordMap)
+    {
+        if(recordMap.size()>10)
+        	recordMap.pollLastEntry();
+    }
+
+    //Quita ultimo elemento asi solo almacena 10 records
+    //Se podria usar una variable que almacene el tiempo maximo ( 999999 ) para comparar con la key
+    public static void invalidParameters(int key, String value)
+    {
+        if(key>= 999999 || value.isEmpty())
+            throw new IllegalArgumentException("parametros invalidos");
+    }
+
+    //mostrar el Map (no es necesario implementar, se puede borrar)
+    public static void mostrarMap(TreeMap<Integer, String> recordMap)
+    {
+        Set<Map.Entry<Integer, String> > entrySet = recordMap.entrySet();
+        Map.Entry<Integer, String>[] entryArray = entrySet.toArray(new Map.Entry[entrySet.size()]);
+
+        for (int indiceMap = 0; indiceMap < recordMap.size(); indiceMap++)
+        {
+            System.out.println("Puntaje " + indiceMap + ": "+ entryArray[indiceMap].getKey());
+            System.out.println("Nombre " + indiceMap + ": "+ entryArray[indiceMap].getValue());
+            System.out.println();
+        }
+    }
+
+}

--- a/TPMagicSquare/src/record/DatosRecordTest.java
+++ b/TPMagicSquare/src/record/DatosRecordTest.java
@@ -1,0 +1,53 @@
+package record;
+
+import static org.junit.Assert.assertTrue;
+import java.util.TreeMap;
+import org.junit.Test;
+
+public class DatosRecordTest
+{
+    private TreeMap<Integer, String> tmap = new TreeMap<Integer, String>();
+
+    //si se agrega una key que se excede de tiempo
+    @Test (expected = IllegalArgumentException.class)
+    public void superaTiempoTest()
+    {
+        DatosRecord.agregarElemento(tmap, 1999999, "Data0");
+    }
+
+    //nombre vacio (invalido)
+    @Test (expected = IllegalArgumentException.class)
+    public void nombreInvalidoTest()
+    {
+    	DatosRecord.agregarElemento(tmap, 0, "");
+    }
+
+    //elimina elemento
+    @Test (expected = IllegalArgumentException.class)
+    public void eliminarElementoTest()
+    {
+    	DatosRecord.agregarElemento(tmap, 0, "Data1");
+    	DatosRecord.agregarElemento(tmap, 1, "Data2");
+    	DatosRecord.agregarElemento(tmap, 2, "Data3");
+    	DatosRecord.agregarElemento(tmap, 3, "Data4");
+    	DatosRecord.agregarElemento(tmap, 4, "Data5");
+    	DatosRecord.agregarElemento(tmap, 5, "Data6");
+    	DatosRecord.agregarElemento(tmap, 6, "Data7");
+    	DatosRecord.agregarElemento(tmap, 7, "Data8");
+    	DatosRecord.agregarElemento(tmap, 8, "Data9");
+    	DatosRecord.agregarElemento(tmap, 9, "Data10");
+    	
+    	DatosRecord.agregarElemento(tmap, 10, "Data11");
+    	
+    	assertTrue(tmap.size()==10);
+    }
+
+    //agregar elemento
+    @Test
+    public void agregarElementoTest()
+    {
+    	DatosRecord.agregarElemento(tmap, 0, "Data1");
+    	assertTrue(tmap.size()==1);
+    }
+
+}


### PR DESCRIPTION
Agrego el paquete récord con dos clases (DatosRecord y DatosRecordTest) 

A la fecha no esta terminado. Falta agregar/corregir test.

Posible problema: si se agrega un récord nuevo al map con un tiempo ya antes agregado. Reemplazara el antiguo tiempo por el nuevo. Debería agregarlo lo mas arriba posible y correr los demás un puesto hacia abajo. Este caso es muy difícil de suceder si tenemos en cuenta los milisegundos. Sin embargo, sigue siendo probable